### PR TITLE
Foreground service

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -23,7 +23,7 @@
         <param name="android-package" value="com.iotum.CordovaAndroidScreenshare" />
       </feature>
     </config-file>
-    <config-file parent="application/service" target="AndroidManifest.xml">
+    <config-file parent="application" target="AndroidManifest.xml">
       <service
         android:name=".MediaProjectionService"
         android:enabled="true"

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,7 +26,7 @@
     </config-file>
     <config-file parent="application" target="AndroidManifest.xml">
       <service
-        android:name=".MediaProjectionService"
+        android:name="com.iotum.CordovaAndroidScreenshare.MediaProjectionService"
         android:enabled="true"
         android:exported="false"
         android:foregroundServiceType="mediaProjection" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,9 +20,9 @@
   <platform name="android">
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="CordovaAndroidScreenshare">
-        <param name="android-package" value="com.iotum.cordovaandroidscreenshare.CordovaAndroidScreenshare" />
+        <param name="android-package" value="com.iotum.CordovaAndroidScreenshare" />
       </feature>
     </config-file>
-    <source-file src="src/android/com/iotum/cordovaandroidscreenshare/CordovaAndroidScreenshare.java" target-dir="src/com/iotum/cordovaandroidscreenshare" />
+    <source-file src="src/android/com/iotum/CordovaAndroidScreenshare.java" target-dir="src/com/iotum" />
   </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,6 +15,7 @@
 
   <js-module src="www/index.js" name="CordovaAndroidScreenshare">
     <clobbers target="CordovaAndroidScreenshare" />
+    <clobbers target="MediaProjectionService" />
   </js-module>
 
   <platform name="android">
@@ -31,5 +32,6 @@
         android:foregroundServiceType="mediaProjection" />
     </config-file>
     <source-file src="src/android/com/iotum/CordovaAndroidScreenshare.java" target-dir="src/com/iotum" />
+    <source-file src="src/android/com/iotum/MediaProjectionService.java" target-dir="src/com/iotum" />
   </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,7 +26,7 @@
     </config-file>
     <config-file parent="application" target="AndroidManifest.xml">
       <service
-        android:name="com.iotum.CordovaAndroidScreenshare.MediaProjectionService"
+        android:name="com.iotum.MediaProjectionService"
         android:enabled="true"
         android:exported="false"
         android:foregroundServiceType="mediaProjection" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -23,6 +23,13 @@
         <param name="android-package" value="com.iotum.CordovaAndroidScreenshare" />
       </feature>
     </config-file>
+    <config-file parent="application/service" target="AndroidManifest.xml">
+      <service
+        android:name=".MediaProjectionService"
+        android:enabled="true"
+        android:exported="false"
+        android:foregroundServiceType="mediaProjection" />
+    </config-file>
     <source-file src="src/android/com/iotum/CordovaAndroidScreenshare.java" target-dir="src/com/iotum" />
   </platform>
 </plugin>

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -1,4 +1,4 @@
-package com.iotum.cordovaandroidscreenshare;
+package com.iotum;
 
 import android.app.Activity;
 import android.content.Context;
@@ -307,6 +307,10 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
    * UI Widget Callbacks
    *******************************/
   private void startProjection() {
+    Intent intent = new Intent(this, MediaProjectionService.class);
+    // Tell the service we want to start it
+    intent.setAction("start");
+    startForegroundService(intent);
     cordova.setActivityResultCallback(this);
     cordova.startActivityForResult(this, mProjectionManager.createScreenCaptureIntent(), REQUEST_CODE);
   }
@@ -321,6 +325,10 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
       public void run() {
         if (sMediaProjection != null) {
           sMediaProjection.stop();
+          Intent intent = new Intent(this, MediaProjectionService.class);
+          // Tell the service we want to start it
+          intent.setAction("stop");
+          startForegroundService(intent);
         }
       }
     });

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -18,7 +18,6 @@ import android.os.Looper;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.Base64;
-import android.view.View;
 import android.view.Display;
 import android.view.OrientationEventListener;
 
@@ -304,7 +303,6 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
   @Override
   public void onDestroy() {
     if (sMediaProjection != null) {
-      
       if (mTimer != null) {
         mTimer.cancel();
         mTimer = null;

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -306,6 +306,11 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
         mTimer = null;
       }
       sMediaProjection.stop();
+      // Stop the foreground service
+      Intent intent = new Intent(activity, MediaProjectionService.class);
+      // Tell the service we want to start it
+      intent.setAction("stop");
+      activity.getApplicationContext().startForegroundService(intent);
     }
   }
 

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -289,12 +289,12 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
 
         // register media projection stop callback
         sMediaProjection.registerCallback(new MediaProjectionStopCallback(), mHandler);
+      } else {
+        // Permission denied, stop the foreground service 
+        Intent intent = new Intent(activity, MediaProjectionService.class);
+        intent.setAction("stop");
+        activity.getApplicationContext().startForegroundService(intent);
       }
-    } else {
-      // Permission denied, stop the foreground service
-      Intent intent = new Intent(activity, MediaProjectionService.class);
-      intent.setAction("stop");
-      activity.getApplicationContext().startForegroundService(intent);
     }
   }
 

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -296,7 +296,7 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
         Activity activity = cordova.getActivity();
         Intent intent = new Intent(activity, MediaProjectionService.class);
         intent.setAction("stop");
-        activity.getApplicationContext().startForegroundService(intent);
+        activity.getApplicationContext().startService(intent);
       }
     }
   }
@@ -314,7 +314,7 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
       Activity activity = cordova.getActivity();
       Intent intent = new Intent(activity, MediaProjectionService.class);
       intent.setAction("stop");
-      activity.getApplicationContext().startForegroundService(intent);
+      activity.getApplicationContext().startService(intent);
     }
   }
 
@@ -329,7 +329,7 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
     Activity activity = cordova.getActivity();
     Intent intent = new Intent(activity, MediaProjectionService.class);
     intent.setAction("start");
-    activity.getApplicationContext().startForegroundService(intent);
+    activity.getApplicationContext().startService(intent);
   }
 
   private void stopProjection() {
@@ -345,7 +345,7 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
           Activity activity = cordova.getActivity();
           Intent intent = new Intent(activity, MediaProjectionService.class);
           intent.setAction("stop");
-          activity.getApplicationContext().startForegroundService(intent);
+          activity.getApplicationContext().startService(intent);
         }
       }
     });

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -257,7 +257,7 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
     Activity activity = cordova.getActivity();
     if (requestCode == REQUEST_CODE) {
       // only continue if permission is granted
-      if (resultCode !== 0) {
+      if (resultCode != 0) {
         sMediaProjection = mProjectionManager.getMediaProjection(resultCode, data);
 
         if (sMediaProjection != null) {

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -260,7 +260,6 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
         sMediaProjection = mProjectionManager.getMediaProjection(resultCode, data);
 
         if (sMediaProjection != null) {
-          Activity activity = cordova.getActivity();
           mReady = true;
           mFps = mPendingFps;
           mCompression = mPendingCompression;
@@ -275,16 +274,16 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
           }, interval, interval);
 
           // display metrics
-          DisplayMetrics metrics = activity.getResources().getDisplayMetrics();
+          DisplayMetrics metrics = cordova.getActivity().getResources().getDisplayMetrics();
           mDensity = metrics.densityDpi;
-          mDisplay = activity.getWindowManager().getDefaultDisplay();
+          mDisplay = cordova.getActivity().getWindowManager().getDefaultDisplay();
           mRotation = mDisplay.getRotation();
 
           // create virtual display depending on device width / height
           createVirtualDisplay(true);
 
           // register orientation change callback
-          mOrientationChangeCallback = new OrientationChangeCallback(activity.getApplicationContext());
+          mOrientationChangeCallback = new OrientationChangeCallback(cordova.getActivity().getApplicationContext());
           if (mOrientationChangeCallback.canDetectOrientation()) {
             mOrientationChangeCallback.enable();
           }

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -307,15 +307,17 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
    * UI Widget Callbacks
    *******************************/
   private void startProjection() {
-    Intent intent = new Intent(this, MediaProjectionService.class);
+    Activity activity = cordova.getActivity();
+    Intent intent = new Intent(activity, MediaProjectionService.class);
     // Tell the service we want to start it
     intent.setAction("start");
-    startForegroundService(intent);
+    activity.getApplicationContext().startForegroundService(intent);
     cordova.setActivityResultCallback(this);
     cordova.startActivityForResult(this, mProjectionManager.createScreenCaptureIntent(), REQUEST_CODE);
   }
 
   private void stopProjection() {
+    Activity activity = cordova.getActivity();
     if (mTimer != null) {
       mTimer.cancel();
       mTimer = null;
@@ -325,10 +327,10 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
       public void run() {
         if (sMediaProjection != null) {
           sMediaProjection.stop();
-          Intent intent = new Intent(this, MediaProjectionService.class);
+          Intent intent = new Intent(activity, MediaProjectionService.class);
           // Tell the service we want to start it
           intent.setAction("stop");
-          startForegroundService(intent);
+          activity.getApplicationContext().startForegroundService(intent);
         }
       }
     });

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -97,8 +97,6 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
     } else if (action.equals("stopProjection")) {
       stopProjection();
       return true;
-    } else if (action.equals("disableWebViewOptimizations")) {
-      disableWebViewOptimizations();
     } else if (action.equals("ping")) {
       callbackContext.success("pong");
       return true;

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -258,6 +258,12 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
     if (requestCode == REQUEST_CODE) {
       // only continue if permission is granted
       if (resultCode != 0) {
+        // Start a mandatory MediaProjection foreground service with a notification for Android SDK 29
+        Activity activity = cordova.getActivity();
+        Intent intent = new Intent(activity, MediaProjectionService.class);
+        intent.setAction("start");
+        activity.getApplicationContext().startForegroundService(intent);
+
         sMediaProjection = mProjectionManager.getMediaProjection(resultCode, data);
 
         if (sMediaProjection != null) {
@@ -292,11 +298,6 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
           // register media projection stop callback
           sMediaProjection.registerCallback(new MediaProjectionStopCallback(), mHandler);
         }
-      } else {
-        // Permission denied, stop the foreground service 
-        Intent intent = new Intent(activity, MediaProjectionService.class);
-        intent.setAction("stop");
-        activity.getApplicationContext().startForegroundService(intent);
       }
     }
   }
@@ -322,11 +323,6 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
    * UI Widget Callbacks
    *******************************/
   private void startProjection() {
-    // Start a mandatory MediaProjection foreground service with a notification for Android SDK 29
-    Activity activity = cordova.getActivity();
-    Intent intent = new Intent(activity, MediaProjectionService.class);
-    intent.setAction("start");
-    activity.getApplicationContext().startForegroundService(intent);
     // Request permission to capture screen
     cordova.setActivityResultCallback(this);
     cordova.startActivityForResult(this, mProjectionManager.createScreenCaptureIntent(), REQUEST_CODE);

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -252,10 +252,15 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
     }.start();
   }
 
-  // TODO: Add logic for rejected permissions
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     if (requestCode == REQUEST_CODE) {
+      // Start the foreground service
+      Intent intent = new Intent(activity, MediaProjectionService.class);
+      // Tell the service we want to start it
+      intent.setAction("start");
+      activity.getApplicationContext().startForegroundService(intent);
+
       sMediaProjection = mProjectionManager.getMediaProjection(resultCode, data);
 
       if (sMediaProjection != null) {
@@ -309,10 +314,6 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
    *******************************/
   private void startProjection() {
     Activity activity = cordova.getActivity();
-    Intent intent = new Intent(activity, MediaProjectionService.class);
-    // Tell the service we want to start it
-    intent.setAction("start");
-    activity.getApplicationContext().startForegroundService(intent);
     cordova.setActivityResultCallback(this);
     cordova.startActivityForResult(this, mProjectionManager.createScreenCaptureIntent(), REQUEST_CODE);
   }

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -255,6 +255,7 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     if (requestCode == REQUEST_CODE) {
+      Activity activity = cordova.getActivity();
       // Start the foreground service
       Intent intent = new Intent(activity, MediaProjectionService.class);
       // Tell the service we want to start it
@@ -278,16 +279,16 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
         }, interval, interval);
 
         // display metrics
-        DisplayMetrics metrics = cordova.getActivity().getResources().getDisplayMetrics();
+        DisplayMetrics metrics = activity.getResources().getDisplayMetrics();
         mDensity = metrics.densityDpi;
-        mDisplay = cordova.getActivity().getWindowManager().getDefaultDisplay();
+        mDisplay = activity.getWindowManager().getDefaultDisplay();
         mRotation = mDisplay.getRotation();
 
         // create virtual display depending on device width / height
         createVirtualDisplay(true);
 
         // register orientation change callback
-        mOrientationChangeCallback = new OrientationChangeCallback(cordova.getActivity().getApplicationContext());
+        mOrientationChangeCallback = new OrientationChangeCallback(activity.getApplicationContext());
         if (mOrientationChangeCallback.canDetectOrientation()) {
           mOrientationChangeCallback.enable();
         }
@@ -318,7 +319,6 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
    * UI Widget Callbacks
    *******************************/
   private void startProjection() {
-    Activity activity = cordova.getActivity();
     cordova.setActivityResultCallback(this);
     cordova.startActivityForResult(this, mProjectionManager.createScreenCaptureIntent(), REQUEST_CODE);
   }

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -76,7 +76,6 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
   private int mCompression;
   private int mPendingFps;
   private int mPendingCompression;
-  private boolean disabledWebViewOptimizations = false;
 
   @Override
   public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -93,14 +92,13 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
       mPendingFps = fps;
       mPendingCompression = compression;
 
-      if (!disabledWebViewOptimizations) {
-        disableWebViewOptimizations();
-      }
       startProjection();
       return true;
     } else if (action.equals("stopProjection")) {
       stopProjection();
       return true;
+    } else if (action.equals("disableWebViewOptimizations")) {
+      disableWebViewOptimizations();
     } else if (action.equals("ping")) {
       callbackContext.success("pong");
       return true;
@@ -371,7 +369,6 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
 
   // enables media playback in the background, needed for Facetalk to extract the mediaStream
   private void disableWebViewOptimizations() {
-    disabledWebViewOptimizations = true;
     Thread thread = new Thread(){
       public void run() {
         try {

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -254,6 +254,7 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
 
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    Activity activity = cordova.getActivity();
     if (requestCode == REQUEST_CODE) {
       sMediaProjection = mProjectionManager.getMediaProjection(resultCode, data);
 
@@ -291,7 +292,6 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
       }
     } else {
       // Permission denied, stop the foreground service
-      Activity activity = cordova.getActivity();
       Intent intent = new Intent(activity, MediaProjectionService.class);
       intent.setAction("stop");
       activity.getApplicationContext().startForegroundService(intent);

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -291,6 +291,12 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
           // register media projection stop callback
           sMediaProjection.registerCallback(new MediaProjectionStopCallback(), mHandler);
         }
+      } else {
+        // stop the foreground service if permission denied
+        Activity activity = cordova.getActivity();
+        Intent intent = new Intent(activity, MediaProjectionService.class);
+        intent.setAction("stop");
+        activity.getApplicationContext().startForegroundService(intent);
       }
     }
   }

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -257,12 +257,6 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
     if (requestCode == REQUEST_CODE) {
       // only continue if permission is granted
       if (resultCode != 0) {
-        // Start a mandatory MediaProjection foreground service with a notification for Android SDK 29
-        Activity activity = cordova.getActivity();
-        Intent intent = new Intent(activity, MediaProjectionService.class);
-        intent.setAction("start");
-        activity.getApplicationContext().startForegroundService(intent);
-
         sMediaProjection = mProjectionManager.getMediaProjection(resultCode, data);
 
         if (sMediaProjection != null) {
@@ -325,6 +319,11 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
     // Request permission to capture screen
     cordova.setActivityResultCallback(this);
     cordova.startActivityForResult(this, mProjectionManager.createScreenCaptureIntent(), REQUEST_CODE);
+    // Start a mandatory MediaProjection foreground service with a notification for Android SDK 29
+    Activity activity = cordova.getActivity();
+    Intent intent = new Intent(activity, MediaProjectionService.class);
+    intent.setAction("start");
+    activity.getApplicationContext().startForegroundService(intent);
   }
 
   private void stopProjection() {

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -254,7 +254,6 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
 
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
-    Activity activity = cordova.getActivity();
     if (requestCode == REQUEST_CODE) {
       // only continue if permission is granted
       if (resultCode != 0) {

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -255,13 +255,6 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     if (requestCode == REQUEST_CODE) {
-      // Only start the MediaProjection foreground service if MediaProjection request is accepted
-      // The service is an empty foreground service with a notification, for Android SDK 29 security purposes
-      Activity activity = cordova.getActivity();
-      Intent intent = new Intent(activity, MediaProjectionService.class);
-      intent.setAction("start");
-      activity.getApplicationContext().startForegroundService(intent);
-
       sMediaProjection = mProjectionManager.getMediaProjection(resultCode, data);
 
       if (sMediaProjection != null) {
@@ -296,6 +289,12 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
         // register media projection stop callback
         sMediaProjection.registerCallback(new MediaProjectionStopCallback(), mHandler);
       }
+    } else {
+      // Permission denied, stop the foreground service
+      Activity activity = cordova.getActivity();
+      Intent intent = new Intent(activity, MediaProjectionService.class);
+      intent.setAction("stop");
+      activity.getApplicationContext().startForegroundService(intent);
     }
   }
 
@@ -320,6 +319,12 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
    * UI Widget Callbacks
    *******************************/
   private void startProjection() {
+    // Start a mandatory MediaProjection foreground service with a notification for Android SDK 29
+    Activity activity = cordova.getActivity();
+    Intent intent = new Intent(activity, MediaProjectionService.class);
+    intent.setAction("start");
+    activity.getApplicationContext().startForegroundService(intent);
+    // Request permission to capture screen
     cordova.setActivityResultCallback(this);
     cordova.startActivityForResult(this, mProjectionManager.createScreenCaptureIntent(), REQUEST_CODE);
   }

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -260,6 +260,7 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
         sMediaProjection = mProjectionManager.getMediaProjection(resultCode, data);
 
         if (sMediaProjection != null) {
+          Activity activity = cordova.getActivity();
           mReady = true;
           mFps = mPendingFps;
           mCompression = mPendingCompression;

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -18,6 +18,7 @@ import android.os.Looper;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.Base64;
+import android.view.View;
 import android.view.Display;
 import android.view.OrientationEventListener;
 
@@ -375,7 +376,7 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
       public void run() {
         try {
           Thread.sleep(1000);
-          getApp().runOnUiThread(() -> {
+          cordova.getActivity().runOnUiThread(() -> {
             View view = webView.getEngine().getView();
 
             try {

--- a/src/android/com/iotum/CordovaAndroidScreenshare.java
+++ b/src/android/com/iotum/CordovaAndroidScreenshare.java
@@ -302,6 +302,7 @@ public class CordovaAndroidScreenshare extends CordovaPlugin {
   @Override
   public void onDestroy() {
     if (sMediaProjection != null) {
+      Activity activity = cordova.getActivity();
       if (mTimer != null) {
         mTimer.cancel();
         mTimer = null;

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -1,6 +1,5 @@
 package com.iotum;
 
-import android.R;
 import android.annotation.TargetApi;
 import android.support.v4.app.NotificationCompat;
 import android.app.Notification;
@@ -32,7 +31,7 @@ public class MediaProjectionService extends Service {
 
             mNotificationId += 1;
             Notification notification = new NotificationCompat.Builder(context, "foreground.service.channel")
-                    .setSmallIcon(android.R.drawable.ic_launcher)
+                    .setSmallIcon(getInstance().cordova.getContext().getApplicationInfo().icon)
                     .setContentTitle("Sharing your screen")
                     .setContentText("Everything on screen will be shared.")
                     .setOngoing(true)

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -29,7 +29,7 @@ public class MediaProjectionService extends Service {
             getSystemService(NotificationManager.class).createNotificationChannel(channel);
 
             mNotificationId += 1;
-            Notifcation notification = new Notification.Builder(context, "foreground.service.channel")
+            Notification notification = new Notification.Builder(context, "foreground.service.channel")
                     .setContentTitle("Sharing your screen")
                     .setContentText("Everything on screen will be shared.")
                     .setOngoing(true)

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -45,7 +45,7 @@ public class MediaProjectionService extends Service {
             }
         } else {
             // Stop the service
-            stopForeground(mNotificationId);
+            stopForeground(true);
             stopSelf();
         }
         return START_STICKY;

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -31,7 +31,7 @@ public class MediaProjectionService extends Service {
 
             mNotificationId += 1;
             Notification notification = new NotificationCompat.Builder(context, "foreground.service.channel")
-                    .setSmallIcon(android.R.drawable.icon)
+                    .setSmallIcon(android.R.drawable.ic_launcher)
                     .setContentTitle("Sharing your screen")
                     .setContentText("Everything on screen will be shared.")
                     .setOngoing(true)

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -1,3 +1,5 @@
+package com.iotum;
+
 import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.Service;

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -31,7 +31,7 @@ public class MediaProjectionService extends Service {
 
             mNotificationId += 1;
             Notification notification = new NotificationCompat.Builder(context, "foreground.service.channel")
-                    .setSmallIcon(android.R.drawable.notification_icon)
+                    .setSmallIcon(android.R.drawable.icon)
                     .setContentTitle("Sharing your screen")
                     .setContentText("Everything on screen will be shared.")
                     .setOngoing(true)

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -27,7 +27,7 @@ public class MediaProjectionService extends Service {
             manager.deleteNotificationChannel("foreground.service.channel");
 
             // Create notification channel
-            NotificationChannel channel = new NotificationChannel("foreground.service.channel", "Background Services", NotificationManager.IMPORTANCE_DEFAULT);
+            NotificationChannel channel = new NotificationChannel("foreground.service.channel", "Background Services", NotificationManager.IMPORTANCE_LOW);
             getSystemService(NotificationManager.class).createNotificationChannel(channel);
 
             mNotificationId += 1;

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -5,9 +5,11 @@ import android.app.Notification;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
 import android.os.Build;
 import android.os.IBinder;
 import android.support.annotation.Nullable;
+import android.support.v7.app.NotificationCompat;
 
 public class MediaProjectionService extends Service {
     private static final String TAG = CordovaAndroidScreenshare.class.getName();

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -17,16 +17,17 @@ import android.support.annotation.Nullable;
 public class MediaProjectionService extends Service {
     private static final String TAG = CordovaAndroidScreenshare.class.getName();
     private int mNotificationId = 0;
-    private NotificationChannel mChannel;
+    private boolean mNotificationChannelExists = false;
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         Context context = getApplicationContext();
         if (intent.getAction().equals("start")) {
-            if (!mChannel) {
+            if (!mNotificationChannelExists) {
                 // Create notification channel
-                mChannel = new NotificationChannel("foreground.service.channel", "Background Services", NotificationManager.IMPORTANCE_LOW);
+                NotificationChannel channel = new NotificationChannel("foreground.service.channel", "Background Services", NotificationManager.IMPORTANCE_LOW);
                 getSystemService(NotificationManager.class).createNotificationChannel(channel);
+                mNotificationChannelExists = true;
             }
 
             mNotificationId += 1;

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -46,7 +46,6 @@ public class MediaProjectionService extends Service {
         } else {
             // Stop the service
             stopForeground(true);
-            stopSelf();
         }
         return START_STICKY;
     }

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -17,18 +17,17 @@ import android.support.annotation.Nullable;
 public class MediaProjectionService extends Service {
     private static final String TAG = CordovaAndroidScreenshare.class.getName();
     private int mNotificationId = 0;
+    private NotificationChannel mChannel;
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         Context context = getApplicationContext();
         if (intent.getAction().equals("start")) {
-            // Delete notification channel if it already exists
-            NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-            manager.deleteNotificationChannel("foreground.service.channel");
-
-            // Create notification channel
-            NotificationChannel channel = new NotificationChannel("foreground.service.channel", "Background Services", NotificationManager.IMPORTANCE_LOW);
-            getSystemService(NotificationManager.class).createNotificationChannel(channel);
+            if (!mChannel) {
+                // Create notification channel
+                mChannel = new NotificationChannel("foreground.service.channel", "Background Services", NotificationManager.IMPORTANCE_LOW);
+                getSystemService(NotificationManager.class).createNotificationChannel(channel);
+            }
 
             mNotificationId += 1;
             Notification notification = new NotificationCompat.Builder(context, "foreground.service.channel")

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -1,6 +1,7 @@
 package com.iotum;
 
 import android.annotation.TargetApi;
+import android.support.v4.app.NotificationCompat;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -29,7 +30,7 @@ public class MediaProjectionService extends Service {
             getSystemService(NotificationManager.class).createNotificationChannel(channel);
 
             mNotificationId += 1;
-            Notification notification = new Notification.Builder(context, "foreground.service.channel")
+            Notification notification = new NotificationCompat.Builder(context, "foreground.service.channel")
                     .setContentTitle("Sharing your screen")
                     .setContentText("Everything on screen will be shared.")
                     .setOngoing(true)

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -1,5 +1,6 @@
 package com.iotum;
 
+import android.R;
 import android.annotation.TargetApi;
 import android.support.v4.app.NotificationCompat;
 import android.app.Notification;

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -31,6 +31,7 @@ public class MediaProjectionService extends Service {
 
             mNotificationId += 1;
             Notification notification = new NotificationCompat.Builder(context, "foreground.service.channel")
+                    .setSmallIcon(android.R.drawable.notification_icon)
                     .setContentTitle("Sharing your screen")
                     .setContentText("Everything on screen will be shared.")
                     .setOngoing(true)

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -31,7 +31,7 @@ public class MediaProjectionService extends Service {
 
             mNotificationId += 1;
             Notification notification = new NotificationCompat.Builder(context, "foreground.service.channel")
-                    .setSmallIcon(getInstance().cordova.getContext().getApplicationInfo().icon)
+                    .setSmallIcon(cordova.getContext().getApplicationInfo().icon)
                     .setContentTitle("Sharing your screen")
                     .setContentText("Everything on screen will be shared.")
                     .setOngoing(true)

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -9,6 +9,7 @@ import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ServiceInfo;
+import android.content.res.Resources;
 import android.os.Build;
 import android.os.IBinder;
 import android.support.annotation.Nullable;

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -2,6 +2,8 @@ package com.iotum;
 
 import android.annotation.TargetApi;
 import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
@@ -20,6 +22,14 @@ public class MediaProjectionService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         Context context = getApplicationContext();
         if (intent.getAction().equals("start")) {
+            // Delete notification channel if it already exists
+            NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            manager.deleteNotificationChannel("foreground.service.channel");
+
+            // Create notification channel
+            NotificationChannel channel = new NotificationChannel("foreground.service.channel", "Background Services", NotificationManager.IMPORTANCE_DEFAULT);
+            getSystemService(NotificationManager.class).createNotificationChannel(channel);
+
             mNotificationId += 1;
             Notification.Builder builder = new Notification.Builder(context, "foreground.service.channel")
                     .setContentTitle(mNotificationTitle)

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -14,8 +14,6 @@ import android.support.annotation.Nullable;
 
 public class MediaProjectionService extends Service {
     private static final String TAG = CordovaAndroidScreenshare.class.getName();
-    private String mNotificationTitle = "Sharing your screen";
-    private String mNotificationText = "Everything on screen will be shared.";
     private int mNotificationId = 0;
 
     @Override
@@ -31,12 +29,12 @@ public class MediaProjectionService extends Service {
             getSystemService(NotificationManager.class).createNotificationChannel(channel);
 
             mNotificationId += 1;
-            Notification.Builder builder = new Notification.Builder(context, "foreground.service.channel")
-                    .setContentTitle(mNotificationTitle)
-                    .setContentText(mNotificationText)
-                    .setOngoing(true);
+            Notifcation notification = new Notification.Builder(context, "foreground.service.channel")
+                    .setContentTitle("Sharing your screen")
+                    .setContentText("Everything on screen will be shared.")
+                    .setOngoing(true)
+                    .build();
 
-            Notification notification = builder.build();
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 startForeground(mNotificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);
             } else {

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -9,7 +9,6 @@ import android.content.pm.ServiceInfo;
 import android.os.Build;
 import android.os.IBinder;
 import android.support.annotation.Nullable;
-import android.support.v7.app.NotificationCompat;
 
 public class MediaProjectionService extends Service {
     private static final String TAG = CordovaAndroidScreenshare.class.getName();
@@ -22,27 +21,15 @@ public class MediaProjectionService extends Service {
         Context context = getApplicationContext();
         if (intent.getAction().equals("start")) {
             mNotificationId += 1;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                Notification.Builder builder = new Notification.Builder(context, "foreground.service.channel")
-                        .setContentTitle(mNotificationTitle)
-                        .setContentText(mNotificationText)
-                        .setOngoing(true);
+            Notification.Builder builder = new Notification.Builder(context, "foreground.service.channel")
+                    .setContentTitle(mNotificationTitle)
+                    .setContentText(mNotificationText)
+                    .setOngoing(true);
 
-                Notification notification = builder.build();
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    startForeground(mNotificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);
-                } else {
-                    startForeground(mNotificationId, notification);
-                }
+            Notification notification = builder.build();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(mNotificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);
             } else {
-                NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
-                        .setContentTitle(mNotificationTitle)
-                        .setContentText(mNotificationText)
-                        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                        .setOngoing(true);
-
-                Notification notification = builder.build();
-
                 startForeground(mNotificationId, notification);
             }
         } else {

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -45,7 +45,8 @@ public class MediaProjectionService extends Service {
             }
         } else {
             // Stop the service
-            stopForeground(true);
+            stopForeground(mNotificationId);
+            stopSelf();
         }
         return START_STICKY;
     }

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -31,7 +31,7 @@ public class MediaProjectionService extends Service {
 
             mNotificationId += 1;
             Notification notification = new NotificationCompat.Builder(context, "foreground.service.channel")
-                    .setSmallIcon(cordova.getContext().getApplicationInfo().icon)
+                    .setSmallIcon(getIconResId())
                     .setContentTitle("Sharing your screen")
                     .setContentText("Everything on screen will be shared.")
                     .setOngoing(true)
@@ -54,5 +54,18 @@ public class MediaProjectionService extends Service {
     @Override
     public IBinder onBind(final Intent intent) {
         return null;
+    }
+
+    private int getIconResId()
+    {
+        Resources res  = getResources();
+        String pkgName = getPackageName();
+
+        int resId = res.getIdentifier("icon", "mipmap", pkgName);
+        if (resId == 0) {
+            resId = res.getIdentifier("icon", "drawable", pkgName);
+        }
+
+        return resId;
     }
 }

--- a/src/android/com/iotum/MediaProjectionService.java
+++ b/src/android/com/iotum/MediaProjectionService.java
@@ -1,0 +1,57 @@
+import android.annotation.TargetApi;
+import android.app.Notification;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+
+public class MediaProjectionService extends Service {
+    private static final String TAG = CordovaAndroidScreenshare.class.getName();
+    private String mNotificationTitle = "Sharing your screen";
+    private String mNotificationText = "Everything on screen will be shared.";
+    private int mNotificationId = 0;
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        Context context = getApplicationContext();
+        if (intent.getAction().equals("start")) {
+            mNotificationId += 1;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                Notification.Builder builder = new Notification.Builder(context, "foreground.service.channel")
+                        .setContentTitle(mNotificationTitle)
+                        .setContentText(mNotificationText)
+                        .setOngoing(true);
+
+                Notification notification = builder.build();
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    startForeground(mNotificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);
+                } else {
+                    startForeground(mNotificationId, notification);
+                }
+            } else {
+                NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
+                        .setContentTitle(mNotificationTitle)
+                        .setContentText(mNotificationText)
+                        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                        .setOngoing(true);
+
+                Notification notification = builder.build();
+
+                startForeground(mNotificationId, notification);
+            }
+        } else {
+            // Stop the service
+            stopForeground(true);
+            stopSelf();
+        }
+        return START_STICKY;
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(final Intent intent) {
+        return null;
+    }
+}

--- a/www/index.js
+++ b/www/index.js
@@ -19,9 +19,6 @@ module.exports = {
       null
     )
   },
-  disableWebViewOptimizations: () => {
-    cordova.exec(null, null, 'MODULE_NAME', 'disableWebViewOptimizations', null);
-  },
   ping: (callback) => {
     cordova.exec(response => callback(response), null, MODULE_NAME, 'ping', null)
   }

--- a/www/index.js
+++ b/www/index.js
@@ -19,6 +19,9 @@ module.exports = {
       null
     )
   },
+  disableWebViewOptimizations: () => {
+    cordova.exec(null, null, 'MODULE_NAME', 'disableWebViewOptimizations', null);
+  },
   ping: (callback) => {
     cordova.exec(response => callback(response), null, MODULE_NAME, 'ping', null)
   }


### PR DESCRIPTION
Start a `mediaProjection` Foreground Service that shows a notification whenever the screenshare is started.

This service/notification MUST be there for `getMediaProjection()` or the app will crash.

Flow goes like this:
1) Facetalk calls `startProjection`
2) `startProjection` starts the Foreground Service
3) Cordova prompts user for permission to screenshare
4) Starts screensharing if accepted, stops Foreground Service if rejected
5) Stops Foreground Service on `stopProjection` or when app is closing

Tested scenarios of rejecting permissions and retrying, and starting screensharing multiple times per call.